### PR TITLE
Update slowquitapps.rb for livecheck

### DIFF
--- a/Casks/slowquitapps.rb
+++ b/Casks/slowquitapps.rb
@@ -5,7 +5,10 @@ cask 'slowquitapps' do
   url "https://github.com/dteoh/SlowQuitApps/releases/download/v#{version}/SlowQuitApps.zip"
   name 'SlowQuitApps'
   homepage 'https://github.com/dteoh/SlowQuitApps'
-  appcast 'https://github.com/dteoh/SlowQuitApps/releases.atom'
+  livecheck do
+    url 'https://github.com/dteoh/SlowQuitApps/releases.atom'
+    strategy :sparkle
+  end
 
   depends_on macos: '>= :mojave'
 


### PR DESCRIPTION
Hello a little contribution that should be solving that issue:

```
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
Please report this issue to the dteoh/sqa tap (not Homebrew/brew or Homebrew/homebrew-core), or ev
en better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/dteoh/homebrew-sqa/Casks/slowquitapps.rb:8
```

Should fix #2